### PR TITLE
Refactor ListInterface for Enhanced Type Compatibility and Simplification

### DIFF
--- a/src/ArrayList.php
+++ b/src/ArrayList.php
@@ -4,7 +4,7 @@ namespace Squille\Cave;
 
 use Iterator;
 
-abstract class ArrayList implements Iterator, ListInterface
+abstract class ArrayList implements ListInterface
 {
     private $index;
     private $items;

--- a/src/ListInterface.php
+++ b/src/ListInterface.php
@@ -4,7 +4,7 @@ namespace Squille\Cave;
 
 use Iterator;
 
-interface ListInterface
+interface ListInterface extends Iterator
 {
     /**
      * @param mixed $item
@@ -28,7 +28,7 @@ interface ListInterface
     public function get($index);
 
     /**
-     * @param Iterator $list
+     * @param ListInterface $list
      */
     public function merge($list);
 


### PR DESCRIPTION
### Changes
This pull request introduces a set of changes aimed at simplifying our list interface structure and resolving type compatibility issues with the `merge` method.

#### Key Modifications:
1. **Updated `ListInterface`**: Now extends the `Iterator` interface to ensure all implementing lists
2. **Updated `ListInterface::merge`**: Now the method accepts another `ListInterface `instead of an `Iterator`, what makes more sense

This was changed to solve an inconsistency that make some IDEs throwing warnings in the classe `MySqlTablesList::missingTableUnconformity`

```php
$createDefinitions = $tableModel->getFields()
    ->merge($tableModel->getConstraints()) // here
    ->merge($tableModel->getIndexes());
``` 